### PR TITLE
fix #144 Fatal Exception: "NSInvalidArgumentException -[__NSArrayM insertObject:atIndex:]: object cannot be nil " in __46+[T8DataBaseModel saveBatchItems:synchronous:]_block_invoke (T8DataBaseModel.m:180)

### DIFF
--- a/T8DataKit/T8DataBaseModel.m
+++ b/T8DataKit/T8DataBaseModel.m
@@ -9,6 +9,10 @@
 #import "T8DataBaseModel.h"
 #import "T8DataBaseManager.h"
 #import <objc/runtime.h>
+#include <pthread.h>
+
+
+static pthread_mutex_t propertyInfoDictLock;
 
 
 @implementation T8DataBaseModel
@@ -292,9 +296,25 @@
     });
     
     NSString *className = [NSStringFromClass([self class]) lowercaseString];
-    NSMutableDictionary *classDict = [propertyInfoDict objectForKey:className];
-    if (classDict==nil) {
-        classDict = [[NSMutableDictionary alloc] init];
+    
+    pthread_mutex_lock(&propertyInfoDictLock);
+    NSDictionary *classDict = [propertyInfoDict objectForKey:className];
+    pthread_mutex_unlock(&propertyInfoDictLock);
+    
+    if (!classDict) {
+        pthread_mutex_lock(&propertyInfoDictLock);
+        //  在执行获取某个类的属性列表操作前再检查一次是否已经有了className对应的classDict，尽量避免（这个方案无法绝对保证同一个class同时只有一个线程在操作）多个线程同时获取同一个class的属性列表（可能有多个线程在同时操作一个className）
+        //  之所以不在获取出行列表的时候加锁是因为：获取属性列表的操作耗时较长，简单的加锁会操成长时间的等待，因此采取允许多个线程同时获取同一个class的属性列表，但是在将获取的属性列表set到propertyInfoDict时进行检查，防止重复插入。只在简单的逻辑判断的地方加锁，在需要长时间操作的地方不加锁。
+        NSDictionary *propertyInfo_before = [propertyInfoDict objectForKey:className];
+        if (propertyInfo_before) {
+            pthread_mutex_unlock(&propertyInfoDictLock);
+            return [propertyInfo_before copy];
+        }
+        pthread_mutex_unlock(&propertyInfoDictLock);
+        
+        
+        NSDictionary *classDict = [[NSMutableDictionary alloc] init];
+        
         Class currentClass = [self class];
         while (currentClass != [T8DataBaseModel class]) {
             unsigned int count;
@@ -307,12 +327,25 @@
                     continue;
                 }
                 NSString *type = [self dbTypeConvertFromObjc_property_t:property];
-                [classDict setObject:type forKey:key];
+                [((NSMutableDictionary *)classDict) setObject:type forKey:key];
             }
             free(properties);
             currentClass = class_getSuperclass(currentClass);
         }
-        [propertyInfoDict setObject:classDict forKey:className];
+        
+        
+        pthread_mutex_lock(&propertyInfoDictLock);
+        //  在获取到某个类的属性列表操作后再检查一次是否已经有了className对应的classDict，防止重复插入相同的className（可能有多个线程在同时操作一个className）
+        NSDictionary *propertyInfo_after = [propertyInfoDict objectForKey:className];
+        if (propertyInfo_after) {
+            pthread_mutex_unlock(&propertyInfoDictLock);
+            return [propertyInfo_after copy];
+        }
+        
+        [propertyInfoDict setObject:[classDict copy] forKey:className];
+        pthread_mutex_unlock(&propertyInfoDictLock);
+        
+        return classDict;
     }
     
     return [classDict copy];


### PR DESCRIPTION
fix Fatal Exception: "NSInvalidArgumentException -[__NSArrayM insertObject:atIndex:]: object cannot be nil " in __46+[T8DataBaseModel saveBatchItems:synchronous:]_block_invoke (T8DataBaseModel.m:180)

1、添加数据验证，为值为nil的变量提供默认值。
2、若primaryKey未提供或提供了NSNull，则直接return。
3、若primaryKey对应的value为nil或NSNull，则跳过直接获取下一个对象。

[T8DataBaseModel.m line 180 #144](https://github.com/tinfinite/saas-ios/issues/144)
